### PR TITLE
BUG FIX: Explicit #import of UIKit for projects that don't rely on precompiled headers (Xcode Modules)

### DIFF
--- a/SDScreenshotCapture/SDScreenshotCapture.h
+++ b/SDScreenshotCapture/SDScreenshotCapture.h
@@ -19,6 +19,8 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+#import <UIKit/UIKit.h>
+
 @interface SDScreenshotCapture : NSObject
 
 + (UIImage *)imageWithScreenshot;


### PR DESCRIPTION
Just a small change that imports UIKit. Hopefully nothing too disruptive!
