### PR TITLE
fix for 'jumping' issue when capturing screenshot

### DIFF
--- a/SDScreenshotCapture/SDScreenshotCapture.m
+++ b/SDScreenshotCapture/SDScreenshotCapture.m
@@ -57,7 +57,7 @@
       CGContextTranslateCTM(context, -imageSize.width, -imageSize.height);
     }
     if ([window respondsToSelector:@selector(drawViewHierarchyInRect:afterScreenUpdates:)]) {
-      [window drawViewHierarchyInRect:window.bounds afterScreenUpdates:YES];
+      [window drawViewHierarchyInRect:window.bounds afterScreenUpdates:NO];
     } else {
       [window.layer renderInContext:context];
     }


### PR DESCRIPTION
I noticed that when capturing a screenshot, sometimes the view would zoom in then immediately zoom back out - I don't know if this is the ideal solution to the issue but it solved it for me.  Let me know what you think.
